### PR TITLE
Add origin header

### DIFF
--- a/NNostr.Client/NostrClient.cs
+++ b/NNostr.Client/NostrClient.cs
@@ -183,6 +183,7 @@ namespace NNostr.Client
 
             websocket?.Dispose();
             websocket = new ClientWebSocket();
+            websocket.Options.SetRequestHeader("origin", _relay.ToString());
             var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             await websocket.ConnectAsync(_relay, cts.Token);
             await WaitUntilConnected(cts.Token);


### PR DESCRIPTION
Some relays will outright reject connections when there is no origin header