### PR TITLE
address serialization issues in 'ToIdPreimage' and 'BaseNostrEventTagJsonConverter'

### DIFF
--- a/NNostr.Client/JsonConverters/BaseNostrEventTagJsonConverter.cs
+++ b/NNostr.Client/JsonConverters/BaseNostrEventTagJsonConverter.cs
@@ -21,11 +21,11 @@ public abstract class BaseNostrEventTagJsonConverter<TNostrEventTag> : JsonConve
         {
             if (i == 0)
             {
-                result.TagIdentifier = StringEscaperJsonConverter.JavaScriptStringEncode(reader.GetString(), false);
+                result.TagIdentifier = reader.GetString();
             }
             else
             {
-                result.Data.Add(StringEscaperJsonConverter.JavaScriptStringEncode(reader.GetString(), false));
+                result.Data.Add(reader.GetString());
             }
 
             reader.Read();

--- a/NNostr.Client/NNostr.Client.csproj
+++ b/NNostr.Client/NNostr.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>11</LangVersion>
@@ -15,8 +15,6 @@
         <license>MIT</license>
         <RepositoryUrl>https://github.com/Kukks/NNostr</RepositoryUrl>
         <PackageTags>Nostr</PackageTags>
-        <TargetFrameworks>net6.0;net7.0;netstandard2.1</TargetFrameworks>    
-
     </PropertyGroup>
 
     <ItemGroup>

--- a/NNostr.Client/NostrEventTag.cs
+++ b/NNostr.Client/NostrEventTag.cs
@@ -1,5 +1,3 @@
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using NNostr.Client.JsonConverters;
 
@@ -8,16 +6,9 @@ namespace NNostr.Client
     [JsonConverter(typeof(NostrEventTagJsonConverter))]
     public class NostrEventTag
     {
-        private static readonly JsonSerializerOptions _unsafeJsonEscapingOptions = new() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
         public string TagIdentifier { get; set; }
         public List<string> Data { get; set; } = new();
 
-        public override string ToString()
-        {
-            var d = TagIdentifier is null ? Data : Data.Prepend(TagIdentifier);
-            return JsonSerializer.Serialize(d, _unsafeJsonEscapingOptions);
-        }
-        
         public bool Equals(NostrEventTag? x, NostrEventTag? y)
         {
             if (ReferenceEquals(x, y)) return true;

--- a/NNostr.Tests/NIP57Tests.cs
+++ b/NNostr.Tests/NIP57Tests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using NNostr.Client;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NNostr.Tests;
+
+public class NIP57Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public NIP57Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Fact]
+    public async Task ValidateZapReceipt()
+    {
+        var privKeyStr = "0514ce6aae1eb9897d32ccce0cc40c6942a1f2f04f5554618dd97f430c9e386f";
+        var privKey = NostrExtensions.ParseKey(privKeyStr);
+        var pubKey = privKey.CreateXOnlyPubKey();
+        var pubKeyHex = pubKey.ToHex();
+
+        var evtRequestStr =
+            """{"id":"cd8bb08cb5a74d67d49d73f8838057385fb8c584427629d81b54e29a1c7708bb","pubkey":"8cacc4de163d6547e740ac4338a3c4569ce4028f0299fae841a00028d68c04e3","created_at":1717408922,"kind":9734,"content":"Great post 👍","tags":[["p","23378c18cb34edc0ea5f979b41703df2799fed769595e31312fef04b8011c0d6"],["amount","21000"],["relays","wss://nostr.mom"],["e","e6dceff3a4cd834edd17c170a41146086e6a200c5f012232bc80840856ddfa27"]],"sig":"a950026e445b27c818013f97a120d1c3c21f94a0e0362379c76cad1a95131ec14071f9b4339afaca2e17144138058db77f415202b92ce52763966fdda97c219d"}""";
+        var evtReceipt = new NostrEvent()
+        {
+            Kind = 9735,
+            Content = "Great post 👍",
+            CreatedAt = DateTimeOffset.FromUnixTimeSeconds(1717408928),
+            PublicKey = pubKeyHex,
+            Tags = {
+                new(){ TagIdentifier = "p", Data = { "23378c18cb34edc0ea5f979b41703df2799fed769595e31312fef04b8011c0d6" }},
+                new(){ TagIdentifier = "e", Data = { "e6dceff3a4cd834edd17c170a41146086e6a200c5f012232bc80840856ddfa27" }},
+                new(){ TagIdentifier = "description", Data = { evtRequestStr }},
+            }
+        };
+        evtReceipt = await evtReceipt.ComputeIdAndSignAsync(privKey);
+        
+        var evtReceiptStr = JsonSerializer.Serialize(evtReceipt);
+
+        _output.WriteLine("Receipt:");
+        _output.WriteLine(evtReceiptStr);
+        
+        // Since we both sign and verify from the same 'ToIdPreimage', this will always succeed, even if the computation of the id is invalid
+        // Use a tool like https://nak.nostr.com/ to copy/paste the event receipt string and verify if the signature is valid
+        Assert.True(evtReceipt.Verify());
+    }
+}


### PR DESCRIPTION
fixes #21

The main issue is with the serialization of special UTF8 characters. The .NET Json serializer (even when using JavaScriptEncoder.UnsafeRelaxedJsonEscaping) insists on encoding special characters as "\uXXX".

This messes up the IdPreimage computation and generates a different Id, and an invalid signature.

See also https://github.com/nostr-protocol/nips/issues/354

I added a unit test to verify this manually (see the comment). An alternative unit test that would verify if the signature is valid should use an alternative/external implementation, but I didn't want to pull in any extra dependencies for now.