### PR TITLE
Fix/nip47 payinvoice json property

### DIFF
--- a/NNostr.Client/NNostr.Client.csproj
+++ b/NNostr.Client/NNostr.Client.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="LinqKit.Core" Version="1.2.5" />
         <PackageReference Include="NBitcoin.Secp256k1" Version="3.1.6" />
         <PackageReference Include="System.Interactive.Async" Version="6.0.1" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="System.Threading.Channels" Version="8.0.0" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/NNostr.Client/Protocols/NIP47.cs
+++ b/NNostr.Client/Protocols/NIP47.cs
@@ -395,6 +395,8 @@ public interface INIP47Request
     public class PayInvoiceRequest : INIP47Request
     {
         public string Method => "pay_invoice";
+
+        [JsonPropertyName("invoice")]
         public string Invoice { get; set; }
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
# Fix PayInvoiceRequest JSON serialization and update System.Text.Json

### Summary
- Fixed missing [JsonPropertyName("invoice")] attribute in PayInvoiceRequest class causing NIP-47 protocol compliance issues
- Updated System.Text.Json from 8.0.4 to 8.0.5 to address security vulnerability CVE-2024-43485

### Problem
The PayInvoiceRequest.Invoice property was missing the [JsonPropertyName("invoice")] attribute, which caused the JSON serialization to not include the required invoice field when using System.Text.Json. This
broke NIP-47 Nostr Wallet Connect protocol compliance.

### Solution
1. JSON Serialization Fix: Added the missing [JsonPropertyName("invoice")] attribute to the Invoice property in PayInvoiceRequest class (line 399 in NNostr.Client/Protocols/NIP47.cs)
2. Security Update: Updated System.Text.Json package reference from version 8.0.4 to 8.0.5 to fix high severity security vulnerability

## Test Coverage
### Added comprehensive unit tests:
- PayInvoiceRequest_SerializesCorrectly() - Verifies that the invoice field is properly included in JSON serialization
- PayInvoiceRequest_WithoutJsonPropertyName_WouldNotSerializeInvoice() - Validates the fix prevents regression

### Breaking Changes
None - this is a bug fix that restores the intended behavior.

### Files Changed
- NNostr.Client/Protocols/NIP47.cs - Added missing JsonPropertyName attribute
- NNostr.Client/NNostr.Client.csproj - Updated System.Text.Json version
- NNostr.Tests/ClientTests.cs - Added comprehensive tests and fixed missing using statement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the “invoice” field is correctly serialized in Pay Invoice request payloads, improving interoperability with NIP-47 services.

* **Chores**
  * Updated JSON serialization library to version 8.0.5 for stability and compatibility.

* **Tests**
  * Added tests to verify correct JSON structure for Pay Invoice requests, including presence and values of method, amount, and invoice fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->